### PR TITLE
Feat: fees add decimals

### DIFF
--- a/contracts/DeltaSwapFactory.sol
+++ b/contracts/DeltaSwapFactory.sol
@@ -14,9 +14,9 @@ contract DeltaSwapFactory is IDeltaSwapFactory {
     address public override gammaPoolSetter;
     address public override gsFactory;
 
-    uint8 public override gsFee = 3; // GammaPool swap fee
-    uint8 public override dsFee = 3; // Fee on large trades
-    uint8 public override dsFeeThreshold = 20; // >2% of Liq trades pay fee
+    uint16 public override gsFee = 300; // GammaPool swap fee
+    uint16 public override dsFee = 300; // Fee on large trades
+    uint16 public override dsFeeThreshold = 2000; // >2% of Liq trades pay fee. TODO: should change to 10 => 1bps
 
     mapping(address => mapping(address => address)) public override getPair;
     address[] public override allPairs;
@@ -67,17 +67,17 @@ contract DeltaSwapFactory is IDeltaSwapFactory {
         feeToSetter = _feeToSetter;
     }
 
-    function setGSFee(uint8 fee) external override {
+    function setGSFee(uint16 fee) external override {
         require(msg.sender == feeToSetter, 'DeltaSwap: FORBIDDEN');
         gsFee = fee;
     }
 
-    function setDSFee(uint8 fee) external override {
+    function setDSFee(uint16 fee) external override {
         require(msg.sender == feeToSetter, 'DeltaSwap: FORBIDDEN');
         dsFee = fee;
     }
 
-    function setDSFeeThreshold(uint8 feeThreshold) external override {
+    function setDSFeeThreshold(uint16 feeThreshold) external override {
         require(msg.sender == feeToSetter, 'DeltaSwap: FORBIDDEN');
         dsFeeThreshold = feeThreshold;
     }
@@ -86,7 +86,7 @@ contract DeltaSwapFactory is IDeltaSwapFactory {
         return(feeTo, feeNum);
     }
 
-    function dsFeeInfo() external override view returns (uint8,uint8) {
+    function dsFeeInfo() external override view returns (uint16,uint16) {
         return(dsFee, dsFeeThreshold);
     }
 

--- a/contracts/DeltaSwapFactory.sol
+++ b/contracts/DeltaSwapFactory.sol
@@ -16,7 +16,7 @@ contract DeltaSwapFactory is IDeltaSwapFactory {
 
     uint16 public override gsFee = 300; // GammaPool swap fee
     uint16 public override dsFee = 300; // Fee on large trades
-    uint16 public override dsFeeThreshold = 2000; // >2% of Liq trades pay fee. TODO: should change to 10 => 1bps
+    uint16 public override dsFeeThreshold = 2000; // >2% of Liq trades pay fee.
 
     mapping(address => mapping(address => address)) public override getPair;
     address[] public override allPairs;

--- a/contracts/DeltaSwapPair.sol
+++ b/contracts/DeltaSwapPair.sol
@@ -116,8 +116,8 @@ contract DeltaSwapPair is DeltaSwapERC20, IDeltaSwapPair {
     }
 
     function calcTradingFee(uint256 tradeLiquidity, uint256 lastLiquidityTradedEMA, uint256 lastLiquidityEMA) public virtual override view returns(uint256) {
-        (uint8 dsFee, uint8 dsFeeThreshold) = IDeltaSwapFactory(factory).dsFeeInfo();
-        if(DSMath.max(tradeLiquidity, lastLiquidityTradedEMA) >= lastLiquidityEMA * dsFeeThreshold / 1000) { // if trade >= threshold, charge fee
+        (uint16 dsFee, uint16 dsFeeThreshold) = IDeltaSwapFactory(factory).dsFeeInfo();
+        if(dsFee > 0 && DSMath.max(tradeLiquidity, lastLiquidityTradedEMA) >= lastLiquidityEMA * dsFeeThreshold / 100000) { // if trade >= threshold, charge fee
             return dsFee;
         }
         return 0;
@@ -271,9 +271,9 @@ contract DeltaSwapPair is DeltaSwapERC20, IDeltaSwapPair {
             } else {
                 fee = IDeltaSwapFactory(factory).gsFee();
             }
-            uint256 balance0Adjusted = balance0 * 1000 - amount0In * fee;
-            uint256 balance1Adjusted = balance1 * 1000 - amount1In * fee;
-            require(balance0Adjusted * balance1Adjusted >= uint256(_reserve0) * _reserve1 * (1000**2), 'DeltaSwap: K');
+            uint256 balance0Adjusted = balance0 * 100000 - amount0In * fee;
+            uint256 balance1Adjusted = balance1 * 100000 - amount1In * fee;
+            require(balance0Adjusted * balance1Adjusted >= uint256(_reserve0) * _reserve1 * (100000**2), 'DeltaSwap: K');
         }
 
         _update(balance0, balance1, _reserve0, _reserve1);

--- a/contracts/interfaces/IDeltaSwapFactory.sol
+++ b/contracts/interfaces/IDeltaSwapFactory.sol
@@ -11,9 +11,9 @@ interface IDeltaSwapFactory {
     function gammaPoolSetter() external view returns (address);
     function gsFactory() external view returns(address);
     function gsProtocolId() external view returns(uint16);
-    function gsFee() external view returns(uint8);
-    function dsFee() external view returns(uint8);
-    function dsFeeThreshold() external view returns(uint8);
+    function gsFee() external view returns(uint16);
+    function dsFee() external view returns(uint16);
+    function dsFeeThreshold() external view returns(uint16);
 
     function getPair(address tokenA, address tokenB) external view returns (address pair);
     function allPairs(uint256) external view returns (address pair);
@@ -27,12 +27,12 @@ interface IDeltaSwapFactory {
 
     function setGSFactory(address factory) external;
     function setGSProtocolId(uint16 protocolId) external;
-    function setGSFee(uint8 fee) external;
-    function setDSFee(uint8 fee) external;
-    function setDSFeeThreshold(uint8 feeThreshold) external;
+    function setGSFee(uint16 fee) external;
+    function setDSFee(uint16 fee) external;
+    function setDSFeeThreshold(uint16 feeThreshold) external;
 
     function feeInfo() external view returns (address,uint16);
-    function dsFeeInfo() external view returns (uint8,uint8);
+    function dsFeeInfo() external view returns (uint16,uint16);
 
     function setGammaPoolSetter(address) external;
     function updateGammaPool(address tokenA, address tokenB) external;

--- a/contracts/libraries/DeltaSwapLibrary.sol
+++ b/contracts/libraries/DeltaSwapLibrary.sol
@@ -20,7 +20,7 @@ library DeltaSwapLibrary {
                 hex'ff',
                 factory,
                 keccak256(abi.encodePacked(token0, token1)),
-                hex'a82767a5e39a2e216962a2ebff796dcc37cd05dfd6f7a149e1f8fbb6bf487658' // init code hash
+                hex'2fecf977542204103c31c2e741ee26e28a43ff3bdae8842e4c91762f9f3ae5b5' // init code hash
                 //hex'7f507cb8f4fb141418e455f4b99d5bd10dbabf9bcc0607d37ceee34013646a9c' // init code hash
             )))));
     }
@@ -44,9 +44,9 @@ library DeltaSwapLibrary {
     function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut, uint256 fee) internal pure returns (uint256 amountOut) {
         require(amountIn > 0, 'DeltaSwapLibrary: INSUFFICIENT_INPUT_AMOUNT');
         require(reserveIn > 0 && reserveOut > 0, 'DeltaSwapLibrary: INSUFFICIENT_LIQUIDITY');
-        uint256 amountInWithFee = amountIn * (1000 - fee);
+        uint256 amountInWithFee = amountIn * (100000 - fee);
         uint256 numerator = amountInWithFee * reserveOut;
-        uint256 denominator = reserveIn * 1000 + amountInWithFee;
+        uint256 denominator = reserveIn * 100000 + amountInWithFee;
         amountOut = numerator / denominator;
     }
 
@@ -54,8 +54,8 @@ library DeltaSwapLibrary {
     function getAmountIn(uint256 amountOut, uint256 reserveIn, uint256 reserveOut, uint256 fee) internal pure returns (uint256 amountIn) {
         require(amountOut > 0, 'DeltaSwapLibrary: INSUFFICIENT_OUTPUT_AMOUNT');
         require(reserveIn > 0 && reserveOut > 0, 'DeltaSwapLibrary: INSUFFICIENT_LIQUIDITY');
-        uint256 numerator = reserveIn * amountOut * 1000;
-        uint256 denominator = (reserveOut - amountOut) * (1000 - fee);
+        uint256 numerator = reserveIn * amountOut * 100000;
+        uint256 denominator = (reserveOut - amountOut) * (100000 - fee);
         amountIn = (numerator / denominator) + 1;
     }
 

--- a/contracts/libraries/DeltaSwapLibrary.sol
+++ b/contracts/libraries/DeltaSwapLibrary.sol
@@ -21,7 +21,7 @@ library DeltaSwapLibrary {
                 factory,
                 keccak256(abi.encodePacked(token0, token1)),
                 hex'2fecf977542204103c31c2e741ee26e28a43ff3bdae8842e4c91762f9f3ae5b5' // init code hash
-                //hex'7f507cb8f4fb141418e455f4b99d5bd10dbabf9bcc0607d37ceee34013646a9c' // init code hash
+                //hex'77f24693a166f241d585911473f08ccdff9442f29bb12fef1b160fce4465ab00' // init code hash
             )))));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-deltaswap",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "GammaSwap feeless spot DEX",
   "main": "index.js",
   "publishConfig": {
@@ -63,6 +63,6 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@gammaswap/v1-core": "^1.1.20"
+    "@gammaswap/v1-core": "^1.2.1"
   }
 }

--- a/test/DeltaSwapFactory.spec.ts
+++ b/test/DeltaSwapFactory.spec.ts
@@ -73,7 +73,7 @@ describe('DeltaSwapFactory', () => {
         const gasPrice = utils.parseUnits('10', 'gwei');  // Set your desired gas price
         const tx = await factory.createPair(...TEST_ADDRESSES, {gasLimit: 9999999, gasPrice: gasPrice})
         const receipt = await tx.wait()
-        expect(receipt.gasUsed).to.eq(2387208)
+        expect(receipt.gasUsed).to.eq(2389638)
     })
 
     it('setFeeTo', async () => {

--- a/test/DeltaSwapPair.spec.ts
+++ b/test/DeltaSwapPair.spec.ts
@@ -172,7 +172,7 @@ describe('DeltaSwapPair', () => {
         await mineBlock(provider, (await provider.getBlock('latest')).timestamp + 1)
         const tx = await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
         const receipt = await tx.wait()
-        expect(receipt.gasUsed).to.eq(131736)
+        expect(receipt.gasUsed).to.eq(131780)
     })
 
     it('burn', async () => {

--- a/test/DeltaSwapRouter01.spec.ts
+++ b/test/DeltaSwapRouter01.spec.ts
@@ -371,8 +371,8 @@ describe('DeltaSwapRouter{01,02}', () => {
                     const receipt = await tx.wait()
                     expect(receipt.gasUsed).to.eq(
                         {
-                            [RouterVersion.DeltaSwapRouter01]: 179874,
-                            [RouterVersion.DeltaSwapRouter02]: 179963
+                            [RouterVersion.DeltaSwapRouter01]: 179962,
+                            [RouterVersion.DeltaSwapRouter02]: 180051
                         }[routerVersion as RouterVersion]
                     )
                 }).retries(3)
@@ -520,8 +520,8 @@ describe('DeltaSwapRouter{01,02}', () => {
                     const receipt = await tx.wait()
                     expect(receipt.gasUsed).to.eq(
                         {
-                            [RouterVersion.DeltaSwapRouter01]: 183509,
-                            [RouterVersion.DeltaSwapRouter02]: 183531
+                            [RouterVersion.DeltaSwapRouter01]: 183597,
+                            [RouterVersion.DeltaSwapRouter02]: 183619
                         }[routerVersion as RouterVersion]
                     )
                 }).retries(3)

--- a/test/DeltaSwapRouter02.spec.ts
+++ b/test/DeltaSwapRouter02.spec.ts
@@ -45,23 +45,23 @@ describe('DeltaSwapRouter02', () => {
 
         let reserveIn = BigNumber.from(5).mul(ONE);
         let reserveOut = BigNumber.from(10).mul(ONE);
-        expect(await router.getAmountOut(swapAmt, reserveIn, reserveOut, 3)).to.eq("1662497915624478906");
+        expect(await router.getAmountOut(swapAmt, reserveIn, reserveOut, 3)).to.eq("1666624999791665624");
 
         reserveIn = BigNumber.from(5).mul(ONE);
         reserveOut = BigNumber.from(10).mul(ONE);
-        expect(await router.getAmountOut(swapAmt.mul(2), reserveIn, reserveOut, 3)).to.eq("2851015155847869602");
+        expect(await router.getAmountOut(swapAmt.mul(2), reserveIn, reserveOut, 3)).to.eq("2857081632128275385");
 
         reserveIn = BigNumber.from(10).mul(ONE);
         reserveOut = BigNumber.from(5).mul(ONE);
-        expect(await router.getAmountOut(swapAmt.mul(2), reserveIn, reserveOut, 3)).to.eq("831248957812239453");
+        expect(await router.getAmountOut(swapAmt.mul(2), reserveIn, reserveOut, 3)).to.eq("833312499895832812");
 
         reserveIn = BigNumber.from(10).mul(ONE);
         reserveOut = BigNumber.from(5).mul(ONE);
-        expect(await router.getAmountOut(swapAmt, reserveIn, reserveOut, 2)).to.eq("453718857974177123");
+        expect(await router.getAmountOut(swapAmt, reserveIn, reserveOut, 2)).to.eq("454537190067618304");
 
         reserveIn = BigNumber.from(10).mul(ONE);
         reserveOut = BigNumber.from(10).mul(ONE);
-        expect(await router.getAmountOut(swapAmt, reserveIn, reserveOut, 2)).to.eq("907437715948354246");
+        expect(await router.getAmountOut(swapAmt, reserveIn, reserveOut, 2)).to.eq("909074380135236609");
 
         reserveIn = BigNumber.from(100).mul(ONE);
         reserveOut = BigNumber.from(100).mul(ONE);

--- a/test/ExampleComputeLiquidityValue.spec.ts
+++ b/test/ExampleComputeLiquidityValue.spec.ts
@@ -249,7 +249,7 @@ describe('ExampleComputeLiquidityValue', () => {
                         105,
                         expandTo18Decimals(5)
                     )
-                ).to.eq('49667') // prev gas 21382
+                ).to.eq('49711') // prev gas 21382
             })
 
             it('gas lower price', async () => {
@@ -261,7 +261,7 @@ describe('ExampleComputeLiquidityValue', () => {
                         95,
                         expandTo18Decimals(5)
                     )
-                ).to.eq('47940') // prev gas 43401
+                ).to.eq('47984') // prev gas 43401
             })
 
             describe('after a swap', () => {
@@ -380,7 +380,7 @@ describe('ExampleComputeLiquidityValue', () => {
                         105,
                         expandTo18Decimals(5)
                     )
-                ).to.eq('54954') // prev gas 26352
+                ).to.eq('54998') // prev gas 26352
             })
 
             it('gas lower price', async () => {
@@ -392,7 +392,7 @@ describe('ExampleComputeLiquidityValue', () => {
                         95,
                         expandTo18Decimals(5)
                     )
-                ).to.eq('53128') // prev gas 26283
+                ).to.eq('53172') // prev gas 26283
             })
 
             describe('after a swap', () => {

--- a/test/ExampleSwapToPrice.spec.ts
+++ b/test/ExampleSwapToPrice.spec.ts
@@ -179,7 +179,7 @@ describe('ExampleSwapToPrice', () => {
                 overrides
             )
             const receipt = await tx.wait()
-            expect(receipt.gasUsed).to.eq('239155')
+            expect(receipt.gasUsed).to.eq('239243')
         }).retries(2) // gas test is inconsistent
     })
 })

--- a/test/foundry/DeltaSwapPair.t.sol
+++ b/test/foundry/DeltaSwapPair.t.sol
@@ -63,7 +63,7 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
 
     function testCalcTradingFee(uint112 tradeLiquidity, uint112 lastLiquidityTradedEMA, uint112 lastLiquidityEMA) public {
         uint256 fee = dsPair.calcTradingFee(tradeLiquidity, lastLiquidityTradedEMA, lastLiquidityEMA);
-        if(DSMath.max(tradeLiquidity, lastLiquidityTradedEMA) >= uint256(lastLiquidityEMA) * dsFactory.dsFeeThreshold() / 1000) {// if trade >= 2% of liquidity, charge 0.3% fee => 1% of liquidity value, ~4.04% px change and 2.3% slippage
+        if(DSMath.max(tradeLiquidity, lastLiquidityTradedEMA) >= uint256(lastLiquidityEMA) * dsFactory.dsFeeThreshold() / 100000) {// if trade >= 2% of liquidity, charge 0.3% fee => 1% of liquidity value, ~4.04% px change and 2.3% slippage
             assertEq(fee,dsFactory.dsFee());
         } else {
             assertEq(fee,0);
@@ -141,10 +141,10 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
 
     function testTradingFeesThreshold() public {
         vm.startPrank(address(dsFactory.feeToSetter()));
-        dsFactory.setDSFeeThreshold(21);
+        dsFactory.setDSFeeThreshold(2100);
         vm.stopPrank();
 
-        assertEq(dsFactory.dsFeeThreshold(), 21);
+        assertEq(dsFactory.dsFeeThreshold(), 2100);
 
         depositLiquidityInCFMM(addr1, 100*1e18, 100*1e18);
         (uint256 reserve0, uint256 reserve1,) = dsPair.getReserves();
@@ -441,10 +441,10 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
 
     function testTradingDSFees() public {
         vm.startPrank(address(dsFactory.feeToSetter()));
-        dsFactory.setDSFee(100); // fee is 10%
+        dsFactory.setDSFee(10000); // fee is 10%
         vm.stopPrank();
 
-        assertEq(dsFactory.dsFee(), 100);
+        assertEq(dsFactory.dsFee(), 10000);
 
         depositLiquidityInCFMM(addr1, 100*1e18, 100*1e18);
         (uint256 reserve0, uint256 reserve1,) = dsPair.getReserves();
@@ -470,7 +470,7 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
     }
 
     function testDSFeesThresholdForbidden() public {
-        uint8 dsFeeThreshold = dsFactory.dsFeeThreshold();
+        uint16 dsFeeThreshold = dsFactory.dsFeeThreshold();
         assertNotEq(dsFeeThreshold, 21);
 
         vm.startPrank(addr1);
@@ -482,7 +482,7 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
     }
 
     function testDSFees() public {
-        assertEq(dsFactory.dsFee(), 3);
+        assertEq(dsFactory.dsFee(), 300);
 
         vm.startPrank(address(dsFactory.feeToSetter()));
         dsFactory.setDSFee(50);
@@ -492,7 +492,7 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
     }
 
     function testDSFeesForbidden() public {
-        uint8 dsFee = dsFactory.dsFee();
+        uint16 dsFee = dsFactory.dsFee();
         assertNotEq(dsFee, 50);
 
         vm.startPrank(addr1);
@@ -554,7 +554,7 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
     }
 
     function testSetGSFee() public {
-        assertEq(dsFactory.gsFee(), 3);
+        assertEq(dsFactory.gsFee(), 300);
 
         vm.startPrank(address(dsFactory.feeToSetter()));
         dsFactory.setGSFee(5);
@@ -605,15 +605,15 @@ contract DeltaSwapPairTest is DeltaSwapSetup {
         vm.expectRevert("DeltaSwap: K");
         dsPair.swap(0, amountOut, poolAddr, new bytes(0));
 
-        amountOut = dsRouter.getAmountOut(amountIn, reserve0, reserve1, 1);
+        amountOut = dsRouter.getAmountOut(amountIn, reserve0, reserve1, 100);
         vm.expectRevert("DeltaSwap: K");
         dsPair.swap(0, amountOut, poolAddr, new bytes(0));
 
-        amountOut = dsRouter.getAmountOut(amountIn, reserve0, reserve1, 2);
+        amountOut = dsRouter.getAmountOut(amountIn, reserve0, reserve1, 200);
         vm.expectRevert("DeltaSwap: K");
         dsPair.swap(0, amountOut, poolAddr, new bytes(0));
 
-        amountOut = dsRouter.getAmountOut(amountIn, reserve0, reserve1, 3);
+        amountOut = dsRouter.getAmountOut(amountIn, reserve0, reserve1, 300);
         dsPair.swap(0, amountOut, poolAddr, new bytes(0));
         vm.stopPrank();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,10 +455,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gammaswap/v1-core@^1.1.20":
-  version "1.1.20"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/1.1.20/70bc7df09404186a5bb993c5880550c537276a46#70bc7df09404186a5bb993c5880550c537276a46"
-  integrity sha512-Cb66rfz7e5vIM97g4e8iD01+G9maB+hrhyyu/j09m7tt5ZC8tjbhcIrbBpsKtXF5n1j8Crm7m8tyA2DirfulaA==
+"@gammaswap/v1-core@^1.2.1":
+  version "1.2.1"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/1.2.1/c5a65f759c77ba9f03e3ab86376771bec1edc2d5#c5a65f759c77ba9f03e3ab86376771bec1edc2d5"
+  integrity sha512-xTraMCQS0W4ZCU0e3v1mCdJ5PkLFdR2d3SAthgZ8DYpmiHe0QjJrgStfRl+I1UprgPlVp0qQygzFiaSeZXGYzQ==
   dependencies:
     "@openzeppelin/contracts" "^4.7.0"
 


### PR DESCRIPTION
-Add more granularity to fee setting in DeltaSwap. Fees and thresholds are now measured in 0.1 basis points
-Updated unit tests